### PR TITLE
Update keywords

### DIFF
--- a/src/syntaxes/hugo.tmLanguage.json
+++ b/src/syntaxes/hugo.tmLanguage.json
@@ -59,12 +59,12 @@
           "name": "constant.numeric.hugo"
         },
         {
-          "match": "\\b(if|else|range|template|with|end|define|where|block|partial)\\b",
+          "match": "\\b(block|define|else|end|if|partial|range|template|where|with)\\b",
           "name": "keyword.control.hugo"
         },
         {
           "name": "support.function.builtin.gotemplate",
-          "match": "\\b(and|call|html|index|js|len|not|or|print|printf|println|urlquery|eq|ne|lt|le|gt|ge)\\b"
+          "match": "\\b(and|call|eq|ge|gt|html|index|js|le|len|lt|ne|not|or|print|printf|println|urlquery)\\b"
         },
         {
           "begin": "\\$\\.",
@@ -80,7 +80,7 @@
           "name": "keyword.operator.initialize.hugo"
         },
         {
-          "match": "\\b(add|delimit|dict|slice|shuffle|echoParam|eq|first|jsonify|last|after|getenv|in|intersect|isset|seq|sort|where|readDir|readFile|imageConfig|int|printf|chomp|dateFormat|emojify|highlight|htmlEscape|htmlUnescape|humanize|lower|markdownify|plainify|pluralize|findRE|replace|replaceRE|safeHTML|safeHTMLAttr|safeCSS|safeJS|singularize|slicestr|truncate|split|string|substr|hasPrefix|title|trim|upper|countwords|countrunes|md5|sha1|sha256|i18n|time|now|absLangURL|relLangURL|absURL|relURL|ref|relref|safeURL|urlize|querify|apply|base64Encode|base64Decode|modBool|union|default)\\b",
+          "match": "\\b(absLangURL|absURL|add|after|anchorize|append|apply|base64Decode|base64Encode|chomp|complement|cond|countrunes|countwords|dateFormat|default|delimit|dict|div|echoParam|emojify|errorf|fileExists|findRE|first|float|getenv|group|hasPrefix|highlight|htmlEscape|htmlUnescape|hugo.BuildDate|hugo.CommitHash|hugo.Environment|hugo.Generator|hugo.IsProduction|hugo.Version|humanize|i18n|imageConfig|in|int|intersect|isset|jsonify|lang.Merge|lang.NumFmt|last|lower|markdownify|math.Ceil|math.Floor|math.Log|math.Round|math.Sqrt|md5|merge|mod|modBool|mul|now|os.Stat|path.Base|path.Dir|path.Ext|path.Join|path.Split|plainify|pluralize|querify|readDir|readFile|ref|reflect.IsMap|reflect.IsSlice|relLangURL|relURL|relref|replace|replaceRE|safeCSS|safeHTML|safeHTMLAttr|safeJS|safeURL|seq|sha1|sha256|shuffle|singularize|slice|slicestr|sort|split|string|strings.HasSuffix|strings.Repeat|strings.RuneCount|strings.TrimLeft|strings.TrimPrefix|strings.TrimRight|strings.TrimSuffix|sub|substr|symdiff|templates.Exists|time|title|transform.Unmarshal|trim|truncate|union|uniq|upper|urlize|urls.Parse|warnf)\\b",
           "name": "support.function.builtin.hugo"
         },
         {


### PR DESCRIPTION
Deletions from support.function.builtin.hugo:

* `where` (it already exists in keyword.control.hugo)
* `eq` (it already exists in support.function.builtin.gotemplate)
* `printf` (it already exists in support.function.builtin.gotemplate)

Additions to support.function.builtin.hugo:

* `anchorize`
* `append`
* `complement`
* `cond`
* `div`
* `errorf`
* `fileExists`
* `float`
* `group`
* `hugo.BuildDate`
* `hugo.CommitHash`
* `hugo.Environment`
* `hugo.Generator`
* `hugo.IsProduction`
* `hugo.Version`
* `lang.Merge`
* `lang.NumFmt`
* `math.Ceil`
* `math.Floor`
* `math.Log`
* `math.Round`
* `math.Sqrt`
* `merge`
* `mod`
* `mul`
* `os.Stat`
* `path.Base`
* `path.Dir`
* `path.Ext`
* `path.Join`
* `path.Split`
* `reflect.IsMap`
* `reflect.IsSlice`
* `strings.HasSuffix`
* `strings.Repeat`
* `strings.RuneCount`
* `strings.TrimLeft`
* `strings.TrimPrefix`
* `strings.TrimRight`
* `strings.TrimSuffix`
* `sub`
* `symdiff`
* `templates.Exists`
* `transform.Unmarshal`
* `uniq`
* `urls.Parse`
* `warnf`

Formatting:

* Alphabetized items in keyword.control.hugo to simplify list maintenance.
* Alphabetized items in support.function.builtin.gotemplate to simplify list maintenance.
* Alphabetized items in support.function.builtin.hugo to simplify list maintenance.
