### PR TITLE
Fix syntax highlighting of global variables.

### DIFF
--- a/src/syntaxes/hugo.tmLanguage.json
+++ b/src/syntaxes/hugo.tmLanguage.json
@@ -68,7 +68,7 @@
         },
         {
           "begin": "\\$\\.",
-          "end": "\\s",
+          "end": "\\s|[\\w.]*",
           "name": "support.function.builtin.hugo"
         },
         {


### PR DESCRIPTION
Fixes colorization when use of a global variable does not end with a space. (i.e. When a var name does not have a space before the end of the hugo tag.)
Ex: "{{$.Site.Params.address}}"   No space before the "}}"
Note: Using \b may be preferable. Ex: "\\s|[^}]*\\b"